### PR TITLE
Add download all button to report section

### DIFF
--- a/resources/ts/Pages/Reports/Sections/Components/ReportSection.tsx
+++ b/resources/ts/Pages/Reports/Sections/Components/ReportSection.tsx
@@ -136,8 +136,26 @@ const ReportSection = ({report, section}: ReportSectionProps) => {
             slice_key: currentSlice,
           })}`}
           size={'xs'}
+          title='Download current slice only'
         >
-          Download
+          Download View
+        </Button>
+        <Button
+          target='_blank'
+          as={ChakraLink}
+          href={`/arbol/series-data/download?${toQueryString({
+            section_id: section.id,
+            series: section.series,
+            slice: section.slice,
+            xaxis_slice: section.xaxis_slice,
+            aggregator: section.aggregator,
+            filters: section.filters,
+            format: section.format,
+          })}`}
+          size={'xs'}
+          title='Download all slices'
+        >
+          Download All
         </Button>
         <Button
           as={Link}


### PR DESCRIPTION
<img width="965" height="237" alt="image" src="https://github.com/user-attachments/assets/aa2cea4c-ef67-47cd-be9c-531f1c474119" />


Previously, the download button gave all slices. In a recent commit, it defaults to a `slice_key`, presumably for performance. Because of this rationale, we are giving the user the option to download all or just the slice subset (the "view") to use at their own discretion.